### PR TITLE
Fix/truncated responses

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rayspock/go-chatgpt-discord
 
-go 1.20
+go 1.21
 
 require (
 	github.com/bwmarrin/discordgo v0.27.1

--- a/handler/helper.go
+++ b/handler/helper.go
@@ -5,28 +5,60 @@ import (
 	"unicode/utf8"
 )
 
+func SendMessageByChunk(message string, maxChunkLength int, send chan<- string) {
+	currentChunkLength := 0
+	chunkStartIndex := 0
+	prevWordDividerIndex := -1
+	for i, w := 0, 0; i < len(message); i += w {
+		currentChunkLength++
+		char, width := utf8.DecodeRuneInString(message[i:])
+		w = width
+
+		// we reach the maximum chunk length
+		if currentChunkLength == maxChunkLength {
+			chunkToSend, nextChunkStartIndex := getChunkToSend(message, i, chunkStartIndex, prevWordDividerIndex)
+			send <- chunkToSend
+			chunkStartIndex = nextChunkStartIndex
+			currentChunkLength = 0
+		} else {
+			if IsWordDivider(char) {
+				prevWordDividerIndex = i
+			}
+		}
+	}
+	if len(message) > 0 && chunkStartIndex < len(message) {
+		send <- message[chunkStartIndex:]
+	}
+	close(send)
+}
+
+func getChunkToSend(message string, byteIndex, chunkStartIndex, prevWordDividerIndex int) (string, int) {
+	char, runeWidth := utf8.DecodeRuneInString(message[byteIndex:])
+	nextChar, _ := utf8.DecodeRuneInString(message[byteIndex+runeWidth:])
+	if !IsWordDivider(char) && !IsWordDivider(nextChar) && prevWordDividerIndex != -1 {
+		chunkToSend := message[chunkStartIndex : prevWordDividerIndex+1]
+		nextChunkStartIndex := prevWordDividerIndex + 1
+		return chunkToSend, nextChunkStartIndex
+	}
+	chunkToSend := message[chunkStartIndex : byteIndex+runeWidth]
+	nextChunkStartIndex := byteIndex + runeWidth
+	return chunkToSend, nextChunkStartIndex
+}
+
+// IsWordDivider returns true if the rune is a word divider.(Currently only space is considered a word divider)
+func IsWordDivider(r rune) bool {
+	return runeMatch(r, []rune{' '})
+}
+
 func getUserMessage(message, author string) string {
 	return fmt.Sprintf("> **%s** - <@%s>\n", message, author)
 }
 
-func SendMessageByChunk(message string, chunkLength int, send chan<- string) {
-	counter := 0
-	lastIndex := 0
-	for i, w := 0, 0; i < len(message); i += w {
-		counter++
-		_, width := utf8.DecodeRuneInString(message[i:])
-		w = width
-
-		// we reach the maximum chunk length
-		if counter == chunkLength {
-			chunk := message[lastIndex : i+w]
-			send <- chunk
-			lastIndex = i + w
-			counter = 0
+func runeMatch(r rune, runes []rune) bool {
+	for _, v := range runes {
+		if r == v {
+			return true
 		}
 	}
-	if len(message) > 0 && lastIndex < len(message) {
-		send <- message[lastIndex:]
-	}
-	close(send)
+	return false
 }

--- a/handler/helper_test.go
+++ b/handler/helper_test.go
@@ -32,6 +32,16 @@ func TestSendMessageByChunk(t *testing.T) {
 			chunkLength:    2,
 			expectedChunks: []string{"¡H", "ol", "a ", "Mu", "nd", "o!"},
 		},
+		"english with word delimiter": {
+			message:        "Hey there, how are you doing?",
+			chunkLength:    11,
+			expectedChunks: []string{"Hey there, ", "how are you", " doing?"},
+		},
+		"mandarin with word delimiter": {
+			message:        "哈囉，你過得好嗎？",
+			chunkLength:    4,
+			expectedChunks: []string{"哈囉，你", "過得好嗎", "？"},
+		},
 	}
 
 	for name, tc := range testCases {


### PR DESCRIPTION
Fix the issue #18  

1. Add word divider check to prevent truncate word for streaming completion
2. Refactor code to make it more readable
3. Upgrade go version to 1.21